### PR TITLE
Removes old version of rubinius references in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
+  - 2.1.1
+  - 2.1.0
+  - 2.0.0
   - 1.9.3
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-18mode
-  - rbx-19mode


### PR DESCRIPTION
Also adds newer ruby versions
