### PR TITLE
Display difference also when type difference is there

### DIFF
--- a/lib/yamldiff/yamldiff.rb
+++ b/lib/yamldiff/yamldiff.rb
@@ -24,7 +24,7 @@ class Yamldiff
 
         value2 = second[key]
         if (value.class != value2.class)
-          errors << YamldiffKeyValueTypeError.new(key, context)
+          errors << YamldiffKeyValueError.new(key, context, Diffy::Diff.new(value.to_s + "\n", value2.to_s + "\n"))
           next
         end
 

--- a/lib/yamldiff/yamldiff_error.rb
+++ b/lib/yamldiff/yamldiff_error.rb
@@ -17,12 +17,6 @@ class YamldiffKeyError < YamldiffError
   end
 end
 
-class YamldiffKeyValueTypeError < YamldiffError
-  def to_s
-    "Key value type mismatch: #{path}"
-  end
-end
-
 class YamldiffKeyValueError < YamldiffError
   attr_reader :diff
 

--- a/spec/lib/yamldiff_error_spec.rb
+++ b/spec/lib/yamldiff_error_spec.rb
@@ -8,14 +8,6 @@ describe YamldiffKeyError, "#to_s" do
   end
 end
 
-describe YamldiffKeyValueTypeError, "#to_s" do
-  subject(:key_value_type_error) { YamldiffKeyValueTypeError.new('key', ['root', 'namespace']) }
-
-  it "outputs human readable text" do
-    expect(key_value_type_error.to_s).to eql "Key value type mismatch: root.namespace.key"
-  end
-end
-
 describe YamldiffKeyValueError, "#to_s" do
   context "without a diff" do
     subject(:key_value_error) { YamldiffKeyValueError.new('key', ['root', 'namespace']) }

--- a/spec/lib/yamldiff_spec.rb
+++ b/spec/lib/yamldiff_spec.rb
@@ -29,7 +29,7 @@ describe Yamldiff do
       second = { a: "1" }
       result = subject.compare_hashes(first, second).first
 
-      expect(result).to be_an_instance_of(YamldiffKeyValueTypeError)
+      expect(result).to be_an_instance_of(YamldiffKeyValueError)
       expect(result.key).to eql :a
       expect(result.context).to be_empty
     end


### PR DESCRIPTION
Using the `YamldiffKeyValueError` for the keytype mismatch scenario such that to display the different values also.